### PR TITLE
keep active form configuration

### DIFF
--- a/extensions/reCaptcha2/SReCaptcha.php
+++ b/extensions/reCaptcha2/SReCaptcha.php
@@ -122,7 +122,10 @@ class SReCaptcha extends CInputWidget
                 $this->attribute = $this->name;
 
             if ($this->hasModel()) {
-                echo CHtml::error($this->model, $this->attribute);
+            	if (method_exists($this->owner, 'error'))
+                    echo $this->owner->error($this->model, $this->attribute);
+            	else
+		            echo CHtml::error($this->model, $this->attribute);
             }
         }
     }


### PR DESCRIPTION
maybe there is more advanced way to achieve this, main goal is to keep all properties I have defined in ActiveForm, to be bypassed to error message renderer

for example, if ActiveForm 'errorMessageCssClass' property is changed, it should be same for this form captcha